### PR TITLE
84-Docker build is now optional

### DIFF
--- a/hcs-relay/pom.xml
+++ b/hcs-relay/pom.xml
@@ -17,45 +17,53 @@
     <description>HCS Relay</description>
 
     <dependencies>
-            <dependency>
+        <dependency>
             <groupId>com.hedera</groupId>
             <artifactId>hcs-lib</artifactId>
             <version>${hcslib.version}</version>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib.version}</version>
-                <configuration>
-                    <from>
-                        <image>gcr.io/distroless/java:11</image>
-                    </from>
-                    <to>
-                        <image>hederahashgraph/hcs-relay</image>
-                        <tags>
-                            <tag>${project.version}</tag>
-                        </tags>
-                    </to>
-                    <extraDirectories>
-                        <paths>
-                            <path>src/main/resources</path>
-                        </paths>
-                    </extraDirectories>
-                    <mainClass>com.hedera.hcsrelay.Launch</mainClass>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>dockerBuild</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
+    <profiles>
+        <!-- profile which adds the possibility to build docker images Call 
+            "mvn clean install -Pdocker" to invoke this additional plugin in the maven 
+            build -->
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <version>${jib.version}</version>
+                        <configuration>
+                            <from>
+                                <image>gcr.io/distroless/java:11</image>
+                            </from>
+                            <to>
+                                <image>hederahashgraph/hcs-relay:latest</image>
+                                <tags>
+                                    <tag>${project.version}</tag>
+                                </tags>
+                            </to>
+                            <extraDirectories>
+                                <paths>
+                                    <path>src/main/resources</path>
+                                </paths>
+                            </extraDirectories>
+                            <mainClass>com.hedera.hcsrelay.Launch</mainClass>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>dockerBuild</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
 </project>

--- a/hcs-sxc-examples/simple-message-demo/docker-compose.yml
+++ b/hcs-sxc-examples/simple-message-demo/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     hcs-relay:
         depends_on:
             - hcsqueue
-        image: hederahashgraph/hcs-relay
+        image: hederahashgraph/hcs-relay:latest
         restart: on-failure
         networks: [backing-services]
 

--- a/hcs-sxc-examples/simple-message-demo/pom.xml
+++ b/hcs-sxc-examples/simple-message-demo/pom.xml
@@ -29,37 +29,45 @@
             <version>${hcslib.version}</version>
         </dependency>
     </dependencies>
-    
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib.version}</version>
-                <configuration>
-                    <to>
-                        <image>hederahashgraph/hcs-app</image>
-                        <tags>
-                            <tag>${project.version}</tag>
-                        </tags>
-                    </to>
-                    <extraDirectories>
-                        <paths>
-                            <path>src/main/resources</path>
-                        </paths>
-                    </extraDirectories>
-                    <mainClass>com.hedera.simple-message-demo.HCSLibCallBackSetup</mainClass>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>dockerBuild</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <!-- profile which adds the possibility to build docker images 
+            Call "mvn clean install -Pdocker" to invoke this additional plugin in the maven build 
+        -->
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <version>${jib.version}</version>
+                        <configuration>
+                            <to>
+                                <image>hederahashgraph/hcs-app:latest</image>
+                                <tags>
+                                    <tag>${project.version}</tag>
+                                </tags>
+                            </to>
+                            <extraDirectories>
+                                <paths>
+                                    <path>src/main/resources</path>
+                                </paths>
+                            </extraDirectories>
+                            <mainClass>com.hedera.simple-message-demo.HCSLibCallBackSetup</mainClass>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>dockerBuild</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
**Detailed description**:
Docker build via maven is now optional, a simple `man install` will not trigger docker images to build. 
In order to build docker images, issue the following command from the top of the project `mvn clean install -Pdocker`

**Which issue(s) this PR fixes**:
Fixes #84

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Changelog updated
- [ ] Readme updated
- [ ] Tests updated