### PR TITLE
added protobuf and more user interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,13 +585,22 @@ Open up to three terminal windows and in each type:
   - terminal 2: linux/mac: `./runapp.sh Player-1`, windows: `runapp.cmd Player-1`
   - terminal 3: linux/mac: `./runapp.sh Player-2`, windows: `runapp.cmd Player-2`
 
-All terminals should now be waiting for input, enter text in one terminal and press [return], after a few seconds, the message should be reflected in all three terminals.
+All terminals should now be waiting for input, after a few seconds, the message should be reflected in all three terminals.
 
 ```
 ****************************************
 ** Welcome to a simple HCS demo
 ** I am app: Player 1
 ****************************************
+Input these commands to interact with the application:
+new `thread_name` to create a new thread (note doesn't change current thread)
+select `thread_name` to switch to `thread_name`
+list to show a list of threads (current thread is highlighted in bold or **)
+show to list all messages for the current thread
+help to print this help
+exit to quit
+
+>
 ```
 
 * With pair-wise encryption
@@ -606,7 +615,7 @@ Open up to three terminal windows and in each type:
 
 All terminals should now be waiting for input, enter text in one terminal and press [return], after a few seconds, the message should be reflected in all or some of the terminals.
 
-Messages sent by player 1 are echoed on Player 2 and 3
+Messages sent by player 1 are echoed on Player 2 and 3, player 1 gets a copy of each message sent
 Messages sent by players 2 and 3 are only echoed on player 1
 
 ```
@@ -614,6 +623,15 @@ Messages sent by players 2 and 3 are only echoed on player 1
 ** Welcome to a simple HCS demo
 ** I am app: Player 1
 ****************************************
+Input these commands to interact with the application:
+new `thread_name` to create a new thread (note doesn't change current thread)
+select `thread_name` to switch to `thread_name`
+list to show a list of threads (current thread is highlighted in bold or **)
+show to list all messages for the current thread
+help to print this help
+exit to quit
+
+>
 ```
 
 #### with relay and queue

--- a/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/pom.xml
+++ b/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/pom.xml
@@ -40,6 +40,13 @@
     </dependencies>
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>        
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -93,6 +100,41 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/proto</source>
+                                <source>target/generated-sources/protobuf/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${protobuf-maven-plugin.version}</version>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
 

--- a/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/java/com/hedera/hcsapp/Ansi.java
+++ b/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/java/com/hedera/hcsapp/Ansi.java
@@ -1,0 +1,30 @@
+package com.hedera.hcsapp;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class Ansi {
+    private static boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
+    private static Map<String, String> colors = new HashMap<String, String>();
+    
+    static {
+        colors.put("(reset)", (isWindows) ? "" : "\u001B[0m"); // reset
+        colors.put("(black)", (isWindows) ? "" : "\u001B[30m"); // black
+        colors.put("(red)", (isWindows) ? "" : "\u001B[31m"); // red
+        colors.put("(green)", (isWindows) ? "" : "\u001B[32m"); // green
+        colors.put("(yellow)", (isWindows) ? "" : "\u001B[33m"); // yellow
+        colors.put("(blue)", (isWindows) ? "" : "\u001B[34m"); // blue
+        colors.put("(purple)", (isWindows) ? "" : "\u001B[35m"); // purple
+        colors.put("(cyan)", (isWindows) ? "" : "\u001B[36m"); // cyan
+        colors.put("(white)", (isWindows) ? "" : "\u001B[37m"); // white
+        colors.put("(bold)", (isWindows) ? "**" : "\033[0;1m"); // bold
+    }
+    
+    public static void print(String toPrint) {
+        for (Entry<String, String> color : colors.entrySet()) {
+            toPrint = toPrint.replace(color.getKey(), color.getValue());
+        }
+        System.out.println(toPrint);
+    }
+}

--- a/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/java/com/hedera/hcsapp/App.java
+++ b/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/java/com/hedera/hcsapp/App.java
@@ -1,5 +1,6 @@
 package com.hedera.hcsapp;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 /*-
  * ‌
  * hcs-sxc-java
@@ -19,14 +20,20 @@ package com.hedera.hcsapp;
  * limitations under the License.
  * ‍
  */
-
 import com.hedera.hcs.sxc.HCSCore;
 import com.hedera.hcs.sxc.callback.OnHCSMessageCallback;
 import com.hedera.hcs.sxc.commonobjects.HCSResponse;
 import com.hedera.hcs.sxc.consensus.OutboundHCSMessage;
 
 import lombok.extern.log4j.Log4j2;
-
+import proto.MessageOnThread;
+import proto.MessageThread;
+import proto.SimpleMessage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Scanner;
 
 /**
@@ -35,19 +42,21 @@ import java.util.Scanner;
  */
 @Log4j2
 public final class App {
-    
+    // eclipse plugin to render ANSI colors in console if needed: mihai-nita.net/2013/06/03/eclipse-plugin-ansi-in-console 
+    private static String messageThread = "";
+    private static Map<String, List<String>> messageThreads = new HashMap<String, List<String>>();
+    private static int topicIndex = 0; // refers to the first topic ID in the config.yaml
+
     public static void main(String[] args) throws Exception {
-        
+
         String appId = "";
         
         if (args.length == 0) {
-            System.out.println("Missing application ID argument");
+            Ansi.print("Missing application ID argument");
             System.exit(0);
         } else {
             appId = args[0];
         }
-        
-        int topicIndex = 0; // refers to the first topic ID in the config.yaml
 
         // 1 - Init the core with data from  .env and config.yaml 
         //HCSCore hcsCore = HCSCore.INSTANCE.singletonInstance(appId);
@@ -55,60 +64,213 @@ public final class App {
                 "./config/config.yaml",
                 "./config/.env"+appId
         );
-        
 
         if (hcsCore.getEncryptMessages()) {
             // 3 - Load the addressbook from address-list yaml and supply the core.
-            AddressListCrypto
-                    .INSTANCE
-                    .singletonInstance(appId)
-                    .getAddressList()
-                    .forEach((k,v)->{
-                        hcsCore.addOrUpdateAppParticipant(k, v.get("theirEd25519PubKeyForSigning"), v.get("sharedSymmetricEncryptionKey"));
-                    });
+            if (AddressListCrypto.INSTANCE.singletonInstance(appId).getAddressList() != null) {
+                AddressListCrypto
+                        .INSTANCE
+                        .singletonInstance(appId)
+                        .getAddressList()
+                        .forEach((k,v)->{
+                            hcsCore.addOrUpdateAppParticipant(k, v.get("theirEd25519PubKeyForSigning"), v.get("sharedSymmetricEncryptionKey"));
+                        });
+            }
         }        
 
-
-        System.out.println("****************************************");
-        System.out.println("** Welcome to a simple HCS demo");
-        System.out.println("** I am app: " + appId);
-        System.out.println("****************************************");
+        Ansi.print("****************************************");
+        Ansi.print("** Welcome to a simple HCS demo");
+        Ansi.print("** I am app: " + appId);
+        Ansi.print("****************************************");
+        showHelp();
         
         // create a callback object to receive the message
         OnHCSMessageCallback onHCSMessageCallback = new OnHCSMessageCallback(hcsCore);
         onHCSMessageCallback.addObserver((HCSResponse hcsResponse) -> {
-            System.out.println("Received : ");
-            System.out.println(new String (hcsResponse.getMessage()));
+            // handle notification in mirrorNotification
+            mirrorNotification(hcsResponse);
         });
 
+        // wait for user input
         Scanner scan = new Scanner(System.in);
         while (true) {
-            
-            // wait for user input
-            System.out.println("Input a message to send to other parties, type exit [RETURN] to exit the application"
-                    + ":");
+            Ansi.print("");
+            Ansi.print("(white)>(reset)");
             String userInput = scan.nextLine();
-           
-            if (userInput.equals("exit")) {
+
+            switch (userInput.toUpperCase()) {
+            case "EXIT":
                 scan.close();
+                Ansi.print("(purple)Goodbye.(reset)");
                 System.exit(0);
+            case "HELP":
+                showHelp();
+                break;
+            case "LIST":
+                //list all threads
+                showThreadList();
+                break;
+            case "SHOW":
+                if (messageThread.isEmpty()) {
+                    Ansi.print("(red)Please create or select a thread first(reset)");
+                } else {
+                    // show all messages in a thread
+                    showThreadMessages();
+                }
+                break;
+            default:
+                if (userInput.isEmpty()) {
+                    Ansi.print("(red)Please input a message before pressing [RETURN].(reset)");
+                } else if (userInput.toUpperCase().startsWith("NEW")) {
+                    // create a new thread 
+                    createNewThread(hcsCore, userInput);
+                } else if (userInput.toUpperCase().startsWith("SELECT")) {
+                    // selects a thread for messages to be sent
+                    selectThread(userInput);
+                } else if (messageThread.isEmpty()) {
+                    Ansi.print("(red)Please create or set a thread first(reset)");
+                } else {
+                    // send message on thread
+                    sendMessageOnThread(hcsCore, messageThread, userInput);
+                }
             }
-            
-            if (userInput.isEmpty()) {
-                System.out.println("Please input a message before pressing [RETURN].");
-            } else {
-                try {
-                    new OutboundHCSMessage(hcsCore)
-                        //.overrideEncryptedMessages(false)
-                        //.overrideMessageSignature(false)
-                        .sendMessage(topicIndex, userInput.getBytes());
+        }            
+    }
     
-                    System.out.println("Message sent successfully.");
+    private static void mirrorNotification(HCSResponse hcsResponse) {
+        // we receive a notification from mirror via HCS core
+        try {
+            // try to parse the notification into a proto
+            SimpleMessage simpleMessage = SimpleMessage.parseFrom(hcsResponse.getMessage());
+            // check the incoming protobuf message for instructions
+            if (simpleMessage.hasMessageOnThread()) {
+                // we have received a new message
+                String message = simpleMessage.getMessageOnThread().getMessage();
+                String threadName = simpleMessage.getMessageOnThread().getThreadName();
+                List<String> messages = messageThreads.get(threadName);
+                messages.add(message);
+                messageThreads.put(threadName, messages);
+                
+                Ansi.print("(green)received new message notification from mirror on thread " 
+                        + "(yellow)" + threadName 
+                        + "(reset), message: " 
+                        + "(yellow)" + message 
+                        + "(reset)");
+            } else if (simpleMessage.hasNewMessageThread()) {
+                // creating a new thread
+                String newThreadName = simpleMessage.getNewMessageThread().getThreadName();
+                messageThreads.put(newThreadName, new ArrayList<String>());
+                Ansi.print("(green)received thread creation notification from mirror: " 
+                        + "(yellow)" + newThreadName 
+                        + "(reset)");
+            }
+        } catch (InvalidProtocolBufferException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private static void showThreadList() {
+        Ansi.print("(cyan)Known threads(reset)");
+        for (Entry<String, List<String>> thread : messageThreads.entrySet()) {
+            System.out.print("  ");
+            if (thread.getKey().equals(messageThread)) {
+                Ansi.print("(bold)" + thread.getKey() + "(reset)");
+            } else {
+                Ansi.print(thread.getKey());
+            }
+        }
+    }
+    
+    private static void showThreadMessages() {
+        Ansi.print("(cyan)Messages in thread " + messageThread + "(reset)");
+        for (String message : messageThreads.get(messageThread)) {
+            System.out.print("  ");
+            Ansi.print(message);
+        }
+    }
+    
+    private static void sendMessageOnThread(HCSCore hcsCore, String threadName, String message) {
+        Ansi.print("Sending... please wait.");
+        // create a protobuf message to carry the message
+        // note, we don't add the message to the thread until we receive notification from mirror
+        // this helps keep consistent state between apps in an appnet
+        MessageOnThread messageOnThread = MessageOnThread.newBuilder()
+                .setThreadName(threadName)
+                .setMessage(message)
+                .build();
+        
+        // wrap the above in a simpleMessage proto
+        SimpleMessage simpleMessage = SimpleMessage.newBuilder()
+                .setMessageOnThread(messageOnThread)
+                .build();
+        
+        try {
+            // Send to HCS
+            new OutboundHCSMessage(hcsCore)
+                .sendMessage(topicIndex, simpleMessage.toByteArray());
+
+            Ansi.print("Message sent to HCS successfully.");
+        } catch (Exception e) {
+            log.error(e);
+        }
+    }
+
+    private static void createNewThread(HCSCore hcsCore, String input) {
+        // remove `THREAD NEW` from the userInput to get the thread name
+        try {
+            String threadName = input.substring("new ".length()).trim();
+            if (messageThreads.containsKey(threadName)) {
+                Ansi.print("(red)Thread already exists(reset)");
+            } else {
+                Ansi.print("Sending... please wait.");
+                // create a protobuf message to carry the new thread
+                // note, we don't add the new thread to the threadlist until we receive notification from mirror
+                // this helps keep consistent state between apps in an appnet
+                MessageThread messageThread = MessageThread.newBuilder()
+                        .setThreadName(threadName)
+                        .build();
+                
+                // wrap the above in a simpleMessage proto
+                SimpleMessage simpleMessage = SimpleMessage.newBuilder()
+                        .setNewMessageThread(messageThread)
+                        .build();
+                try {
+                    // Send to HCS
+                    new OutboundHCSMessage(hcsCore)
+                        .sendMessage(topicIndex, simpleMessage.toByteArray());
+                    Ansi.print("Thread create message sent to HCS");
                 } catch (Exception e) {
                     log.error(e);
                 }
             }
-        }            
+        } catch (StringIndexOutOfBoundsException e) {
+            Ansi.print("(red)Invalid input(reset)");
+        }
+    }
+    
+    private static void selectThread(String input) {
+        // remove `THREAD SELECT` from the userInput to get the thread name
+        try {
+            String threadName = input.substring("select ".length()).trim();
+            if (! messageThreads.containsKey(threadName)) {
+                Ansi.print("(red)Unknown thread(reset)");
+            } else {
+                messageThread = threadName;
+                Ansi.print(threadName + " is the current thread");
+            }
+        } catch (StringIndexOutOfBoundsException e) {
+            Ansi.print("(red)Invalid input(reset)");
+        }
+    }
+    
+    private static void showHelp() {
+        Ansi.print("Input these commands to interact with the application:");
+        Ansi.print("(cyan)new (yellow)thread_name(reset) to create a new thread (purple)(note doesn't change current thread)(reset)");
+        Ansi.print("(cyan)select (yellow)thread_name(reset) to create a new thread (purple)(note doesn't change current thread)(reset)");
+        Ansi.print("(cyan)list(reset) to show a list of threads");
+        Ansi.print("(cyan)show(reset) to list all messages for the current thread");
+        Ansi.print("(cyan)help(reset) to print this help");
+        Ansi.print("(cyan)exit(reset) to quit");
     }
 }
        

--- a/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/proto/simple-messages.proto
+++ b/hcs-sxc-java-examples/hcs-sxc-java-simple-message-demo/src/main/proto/simple-messages.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package proto;
+
+//option java_package = "com.hedera...";
+option java_multiple_files = true;
+
+message MessageThread {
+    string threadName = 1;
+}
+
+message MessageOnThread {
+    string threadName = 1;
+    string message = 2;
+}
+
+message SimpleMessage {
+    oneof data {
+        MessageThread newMessageThread = 1;
+        MessageOnThread messageOnThread = 2;
+    }
+}
+        


### PR DESCRIPTION
Signed-off-by: Greg Scullard <gregscullard@hedera.com>

**Detailed description**:
Simple demo now follows a similar pattern to settlement demo and is therefore a better example of how to use hcs-sxc, while remaining simple.

Fixes #431 

Messages sent are now inside threads (conversation threads), it is possible to 
1. create a new thread (e.g. `new summer holiday`)
2. select a thread to converse on (e.g. `select summer holiday`)
3. send a message on a given thread (`it was a great holiday`)
4. list threads (`list` - current thread is highlighted in bold or prefixed with **)
5. recall messages in the current thread (`show`)

Note: We could have used different topics, but that's a different demo scenario, the idea here was to better examplify use of protobuf messages sent from a an app to HCS, receiving this message and processing it through notifications while holding some simple state (threads and messages in threads).
Note: Per the settlement demo, creating a thread or message isn't reflected in state until the corresponding message has been notified by mirror node.

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [ ] Changelog updated
- [ ] Readme updated
- [ ] Tests updated
